### PR TITLE
[feat] 라우터 추가(2차) , 레이아웃 컴포넌트 props 수정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,17 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import './styles/reset.css';
+// import LoginMain from './pages/Login/LoginMain/LoginMain';
 import Feed from './pages/Feed/Feed';
-import LoginMain from './pages/Login/LoginMain/LoginMain';
+import SearchUser from './pages/SearchUser/SearchUser.jsx';
 import Join from './pages/Join/JoinEmail/JoinEmail';
+import JoinProfileSetting from './pages/Join/JoinProfileSetting/JoinProfileSetting';
 import MyProfile from './pages/Profile/MyProfile/MyProfile';
+import ProfileModification from './pages/ProfileModification/ProfileModification';
+import AddProduct from './pages/Product/AddProduct';
+import YourProfile from './pages/Profile/YourProfile';
+import PostDetail from './pages/Post/PostDetail';
+import Upload from './pages/Upload/Upload';
+import ChatRoom from './pages/Chat/ChatRoom/ChatRoom';
 import ChatList from './pages/Chat/ChatList/ChatList';
 
 export default function App() {
@@ -12,10 +20,30 @@ export default function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Feed />}></Route>
-          <Route path="/login" element={<LoginMain />}></Route>
-          <Route path="/join" element={<Join />}></Route>
-          <Route path="/profile" element={<MyProfile />}></Route>
-          <Route path="/chat" element={<ChatList />}></Route>
+          <Route path="/search" element={<SearchUser />}></Route>
+          {/* <Route path="/login" element={<LoginMain />}></Route> */}
+          <Route path="/join">
+            <Route index element={<Join />} />
+            <Route path="profile" element={<JoinProfileSetting />} />
+          </Route>
+          <Route path="/profile">
+            <Route index element={<MyProfile />} />
+            <Route path="m" element={<ProfileModification />} />
+            <Route path="product/add" element={<AddProduct />} />
+            {/* AddProduct와 ProductModi 페이지 분리 필요! 또는 공통된 이름으로 파일명을 바꾸고, 안에서 조건에 따라 렌더링 되도록 하는 등의 분리가 필요함 */}
+            <Route path="product/m" element={<AddProduct />} />
+            {/* 변경 예정:  profile/{id} */}
+            <Route path="profile/1234" element={<YourProfile />} />
+          </Route>
+          <Route path="/post">
+            <Route index element={<PostDetail />} />
+            <Route path="upload" element={<Upload />} />
+          </Route>
+          <Route path="/chat">
+            <Route index element={<ChatList />} />
+            {/* 변경 예정:  chat/{id} */}
+            <Route path="1234" element={<ChatRoom />} />
+          </Route>
         </Routes>
       </BrowserRouter>
     </>

--- a/src/components/Common/HeaderTest/Header.jsx
+++ b/src/components/Common/HeaderTest/Header.jsx
@@ -4,25 +4,7 @@ import IconArrowLeft from '../../../assets/images/icon-arrow-left.svg';
 import IconMoreVertical from '../../../assets/images/s-icon-more-vertical.svg';
 import IconSearch from '../../../assets/images/icon-search.svg';
 
-export default function Header() {
-  let type;
-  switch (document.location.pathname) {
-    case '/':
-      type = 'homeSearch';
-      break;
-    case '/profile':
-      type = 'header';
-      break;
-    case '/post':
-      type = 'header';
-      break;
-    case '/chat':
-      type = 'chat';
-      break;
-    default:
-      type = 'none';
-      break;
-  }
+export default function Header({ type }) {
   const HeaderUI = {
     none: <></>,
     header: (

--- a/src/components/Common/Post/Post.module.css
+++ b/src/components/Common/Post/Post.module.css
@@ -139,6 +139,7 @@
   height: 228px;
   border: 0.5px solid #DBDBDB;
   border-radius: 10px;
+  margin-right: 2px;
 }
 .post-img-list li.on{
   transform: all 0.5s;

--- a/src/components/Common/Profile/ProfilePost.module.css
+++ b/src/components/Common/Profile/ProfilePost.module.css
@@ -1,4 +1,7 @@
 /* 포스트 */
+.post {
+  background-color: #ffffff;
+}
 .btn-group {
   text-align: right;
   padding: 9px 21px;
@@ -13,5 +16,5 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
-  padding: 16px;
+  padding: 30px 16px;
 }

--- a/src/components/common/Profile/ProfileProduct.module.css
+++ b/src/components/common/Profile/ProfileProduct.module.css
@@ -1,19 +1,14 @@
 @import '../../../styles/global.css';
 @import '../../../assets/font/font.css';
 
-body {
-  font-family: 'Pretendard';
-  color: #C4C4C4;
-  text-align: center;  
-}
-
 /* ===== 공구중인 상품 ===== */
 .product {
   height: 208px;
   text-align: left;
   padding: 21px 0 20px 16px;
-  border-top: 6px solid #DBDBDB;
-  border-bottom: 6px solid #DBDBDB;
+  border-top: 3px solid #DBDBDB;
+  border-bottom: 3px solid #DBDBDB;
+  background: #ffffff;
 }
 .product-title {
   font-weight: 700;

--- a/src/components/common/TabMenu/TabMenu.jsx
+++ b/src/components/common/TabMenu/TabMenu.jsx
@@ -1,22 +1,7 @@
 import React from 'react';
 import styles from './TabMenu.module.css';
 
-export default function TabMenu() {
-  let type;
-  switch (document.location.pathname) {
-    case '/':
-      type = 'home';
-      break;
-    case '/profile':
-      type = 'profile';
-      break;
-    case '/chat':
-      type = 'chat';
-      break;
-    default:
-      type = 'none';
-      break;
-  }
+export default function TabMenu({ type }) {
   const TabMenuUI = {
     none: <></>,
     home: (

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -5,21 +5,44 @@ import TabMenu from '../common/TabMenu/TabMenu';
 import Input from '../common/Input/Input';
 
 export default function Layout({ children }) {
-  let type;
-  switch (document.location.pathname) {
-    case '/post':
-      type = 'input';
-      break;
+  let headerType;
+  let footerType;
 
+  switch (document.location.pathname) {
+    case '/':
+      headerType = 'header';
+      footerType = 'home';
+      break;
+    case '/profile':
+      headerType = 'header';
+      footerType = 'profile';
+      break;
+    case '/post':
+      headerType = 'header';
+      footerType = 'comment';
+      break;
+    case '/chat':
+      headerType = 'chat';
+      footerType = 'chat';
+      break;
+    case '/search':
+      headerType = 'userSearch';
+      break;
     default:
+      headerType = 'none';
+      footerType = 'none';
       break;
   }
   return (
     <>
-      <Header />
+      <Header type={headerType} />
       <main>{children}</main>
       <footer>
-        {type === 'input' ? <Input type="comment" /> : <TabMenu />}
+        {footerType === 'input' || footerType === 'comment' ? (
+          <Input type={footerType} />
+        ) : (
+          <TabMenu type={footerType} />
+        )}
       </footer>
     </>
   );

--- a/src/components/layout/Layout.module.css
+++ b/src/components/layout/Layout.module.css
@@ -1,6 +1,3 @@
-@import '../../styles/global.css';
-@import '../../assets/font/font.css';
-
 header {
   position: fixed;
   top: 0;
@@ -19,11 +16,12 @@ footer {
   width: 100%;
   height: 60px;
   min-width: 390px;
+  background-color: #ffffff;
 }
 
 main {
   width: 390px;
   min-width: 390px;
-  /* 피드에서 30px의 상단 마진이 추가로 있어서 적용했습니다. */
-  margin: 78px auto 60px;
+  margin: 48px auto 60px;
+  background-color: #ffffff;
 }


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 폴더, 파일 등 업로드
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 기존에 feed, login, join, profile, chat만 연결된 상태에서, 아래 구조로 라우터 추가합니다.
----
 - `/login`
- `/join`
    - `/join/profile/m`
- `/`
- `/search`
- `/profile`
    - `/profile/followers`
    - `/profile/m`
    - `/profile/product/add`
    - `/profile/product/m`
    - `/profile/{id}`
- `/post/{id}`
    - `/post/upload`
- `/chat`
    - `/chat/{id}` 
----
- 레이아웃 컴포넌트 props 전달방식 수정(Header.jsx, TabMenu.jsx 내부에서 조건에 따라 리턴하던 로직에서, Layout.jsx에서 switch로 설정한 props를 전달하는 방식으로 수정)
## 이슈 번호
closed: #70 