### PR TITLE
[✨feat] 회원가입 페이지 api연동 및 기능 구현 #100

### DIFF
--- a/src/api/userAPI.js
+++ b/src/api/userAPI.js
@@ -1,0 +1,93 @@
+import BASE_URL from '../utils/baseUrl';
+
+const userAPI = {
+  async getSignUp(username, email, password, accountname, intro, image) {
+    const userData = {
+      user: {
+        username,
+        email,
+        password,
+        accountname,
+        intro,
+        image,
+      },
+    };
+
+    const response = await fetch(`${BASE_URL}/user`, {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify(userData),
+    });
+
+    const data = await response.json();
+    return data;
+  },
+
+  async getLogin(email, password) {
+    const response = await fetch(`${BASE_URL}/user/login`, {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        user: {
+          email,
+          password,
+        },
+      }),
+    });
+    const data = await response.json();
+    return data;
+  },
+
+  async checkEmailValid(email) {
+    const response = await fetch(`${BASE_URL}/user/emailvalid`, {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        user: {
+          email,
+        },
+      }),
+    });
+    const data = await response.json();
+    return data;
+  },
+
+  async checkAccountValid(email) {
+    console.log('userApi.js-email :', email);
+
+    const response = await fetch(`${BASE_URL}/user/emailvalid`, {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        user: {
+          email: email,
+        },
+      }),
+    });
+    const responseJson = await response.json();
+    return responseJson;
+  },
+
+  async getMyInfo(token) {
+    console.log('token : ', token);
+    const response = await fetch(`${BASE_URL}/user/myinfo`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await response.json();
+    console.log('data : ', data);
+    return data;
+  },
+};
+
+export default userAPI;

--- a/src/pages/Join/JoinEmail/JoinEmail.jsx
+++ b/src/pages/Join/JoinEmail/JoinEmail.jsx
@@ -77,7 +77,7 @@ export default function JoinEmail() {
           )}
           {!isEmailValid && (
             <small className={styles['error-message']} role="alert">
-              이미 사용 중인 이메일입니다.
+              *이미 사용 중인 이메일입니다.
             </small>
           )}
         </div>

--- a/src/pages/Join/JoinEmail/JoinEmail.jsx
+++ b/src/pages/Join/JoinEmail/JoinEmail.jsx
@@ -1,20 +1,50 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './JoinEmail.module.css';
 import { useForm } from 'react-hook-form';
+import userAPI from '../../../api/userAPI';
+import { useNavigate } from 'react-router-dom';
 
-export default function JoinEmail({
-  onSubmit = async data => {
-    await new Promise(r => setTimeout(r, 1000));
-    alert(JSON.stringify(data));
-  },
-}) {
+export default function JoinEmail() {
+  const navigate = useNavigate();
+
   const {
     register,
     handleSubmit,
     formState: { isSubmitting, isDirty, errors },
+    setValue,
+    watch,
   } = useForm();
 
-  const isFormValid = isDirty && Object.keys(errors).length === 0;
+  const [isEmailValid, setIsEmailValid] = useState(true);
+
+  const handleEmailChange = event => {
+    const email = event.target.value;
+    setValue('email', email); // Update form value
+    setIsEmailValid(true); // Reset email validation
+  };
+
+  const onSubmit = async data => {
+    try {
+      const email = data.email;
+      const response = await userAPI.checkAccountValid(email);
+      console.log(response.message);
+
+      if (response.message === '사용 가능한 이메일 입니다.') {
+        navigate('/join/profile', {
+          state: {
+            email: data.email,
+            password: data.password,
+          },
+        });
+      } else {
+        setIsEmailValid(false);
+      }
+    } catch (error) {
+      console.error(error);
+      setIsEmailValid(true);
+      alert('회원가입에 실패하였습니다.');
+    }
+  };
 
   return (
     <main>
@@ -27,13 +57,11 @@ export default function JoinEmail({
           </label>
           <input
             id="email"
-            type="text"
-            name="email"
+            type="email"
             placeholder="이메일 주소를 입력해주세요."
             className={styles['input']}
-            aria-invalid={
-              !isDirty ? undefined : errors.email ? 'true' : 'false'
-            }
+            aria-invalid={!isEmailValid}
+            onChange={handleEmailChange}
             {...register('email', {
               required: '*이메일은 필수 입력입니다.',
               pattern: {
@@ -47,6 +75,11 @@ export default function JoinEmail({
               {errors.email.message}
             </small>
           )}
+          {!isEmailValid && (
+            <small className={styles['error-message']} role="alert">
+              이미 사용 중인 이메일입니다.
+            </small>
+          )}
         </div>
 
         {/* 패스워드 인풋*/}
@@ -57,7 +90,6 @@ export default function JoinEmail({
           <input
             id="password"
             type="password"
-            name="password"
             placeholder="비밀번호를 입력해주세요."
             className={styles['input']}
             aria-invalid={
@@ -79,9 +111,9 @@ export default function JoinEmail({
         </div>
         {/* 버튼 */}
         <button
-          disabled={isSubmitting || !isFormValid} // 유효성 검사를 통과하지 않으면 버튼 비활성화
+          disabled={isSubmitting} // 유효성 검사를 통과하지 않으면 버튼 비활성화
           className={`${styles['submit-btn']} ${
-            isFormValid ? styles['submit-btn-active'] : ''
+            isSubmitting ? styles['submit-btn-active'] : ''
           }`}
           type="submit"
         >

--- a/src/pages/Join/JoinProfileSetting/JoinProfileSetting.jsx
+++ b/src/pages/Join/JoinProfileSetting/JoinProfileSetting.jsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import styles from './JoinProfileSettiong.module.css';
 import BasicProfile from '../../../assets/images/basic-profile-img.png';
 import ImgButton from '../../../assets/images/img-button.png';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function JoinProfileSetting({
   onSubmit = async data => {
@@ -17,6 +18,10 @@ export default function JoinProfileSetting({
   } = useForm();
 
   const isFormValid = isDirty && Object.keys(errors).length === 0;
+  // join 페이지에서 navigate로 보낸 값을 여기서 받아서 씀
+  const location = useLocation();
+  const data = location.state;
+  console.log('data:', data);
 
   return (
     <main>

--- a/src/utils/baseUrl.js
+++ b/src/utils/baseUrl.js
@@ -1,2 +1,2 @@
-const BASE_URL = 'https://api.mandarin.weniv.co.kr/';
+const BASE_URL = 'https://api.mandarin.weniv.co.kr';
 export default BASE_URL;


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 폴더, 파일 등 업로드
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- api 폴더에 userAPI 추가함
- base url 수정 뒤에 '/' 삭제
- 기능 구현
  1. 이메일 api 연동을 통한 중복 검사 완료
  2. 비밀번호 6자 미만일 경우 경고 문구와 버튼 비활성화 기능 완료
  3. 완료 ⇒ (회색 #DBDBDB → 갈색7D4B0F)
  4. 값을 올바르게 넣으면 다음 버튼 활성 완료
   - 다음 버튼 누르면 프로필 설정으로 넘어가짐

## 이슈 번호
closed: #100 