### PR TITLE
[fix] 프로필 페이지에서 게시글 앨범으로 보기 이미지 분리하는 로직 수정 #167

### DIFF
--- a/src/components/common/Profile/ProfilePost.jsx
+++ b/src/components/common/Profile/ProfilePost.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import Post from '../Post/Post';
 import styles from './ProfilePost.module.css';
 import postAPI from '../../../api/postAPI';
@@ -76,7 +75,6 @@ export default function ProfilePost({
       case 'profile':
         fetchUserPost();
         break;
-
       default:
         break;
     }
@@ -84,7 +82,7 @@ export default function ProfilePost({
 
   const userPostImgArray = [];
   userPost.forEach(element => {
-    element['image'] !== ''
+    element['image']
       ? userPostImgArray.push(element['image'])
       : console.log('이미지 없어유');
   });


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 폴더, 파일 등 업로드
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 프로필 페이지에서 게시글 앨범으로 보기를 위해 이미지 분리하는 로직 수정 

## 이슈 번호
closed: #167 