### PR TITLE
[fix] YourProfile 페이지에서 공유버튼 클릭 시, 전체 url 복사 되도록 수정 #208

### DIFF
--- a/src/components/common/Profile/OtherProfile.jsx
+++ b/src/components/common/Profile/OtherProfile.jsx
@@ -13,6 +13,7 @@ export default function UserProfile({ alertOpen }) {
   const [isLoading, setIsLoading] = useState(false);
   const [followerCount, setFollowerCount] = useState(0);
   const [isFollow, setIsFollow] = useState(false);
+  const url = window.location.href;
   const navigate = useNavigate();
 
   const fetchProfile = async () => {
@@ -81,8 +82,7 @@ export default function UserProfile({ alertOpen }) {
   };
   const shareClickHandler = () => {
     console.log('공유하기');
-    // 없어도 실행됨
-    // navigator.clipboard.writeText(url);
+    navigator.clipboard.writeText(url);
     alertOpen();
   };
 


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [x] 버그 수정

## 변경 사항
- YourProfile 페이지에서 공유하기 버튼 클릭 시, http://localhost:3000/만 복사되던 이슈를 전체 url이 복사되도록 수정

## 이슈 번호
closed: #208 