### PR TITLE
[fix] 게시글에서 일정 중 일시가 렌더링 될 때 날짜를 계산하도록 수정 #214

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -85,8 +85,8 @@ export default function Post({ data, accountName, modalOpen, getPostId }) {
   };
 
   // 게시글 하단 작성 일자
-  const formattedDate = formateCreateDate(data['createdAt']);
-  function formateCreateDate(dateString) {
+  const formattedCreateDate = formatCreateDate(data['createdAt']);
+  function formatCreateDate(dateString) {
     const currentDate = new Date();
     const targetDate = new Date(dateString);
 
@@ -123,6 +123,44 @@ export default function Post({ data, accountName, modalOpen, getPostId }) {
   const match = contentTxt?.match(regex);
   const foundText = match ? match[0] : null;
   const planContents = foundText ? JSON.parse(foundText) : null;
+
+  // 게시글 내 일정 > 일시
+  const formattedPlanDate =
+    planContents && formatPlanDate(planContents['date']);
+  function formatPlanDate(date) {
+    // '시'가 포함되어 있으면 그냥 return
+    if (date.includes('시')) {
+      return date;
+    }
+
+    const currentDate = new Date();
+    const targetDate = new Date(date);
+
+    const isToday = currentDate.toDateString() === targetDate.toDateString();
+
+    if (isToday) {
+      const hours = targetDate.getHours();
+      const minutes = targetDate.getMinutes();
+      return `오늘, ${hours}시 ${minutes}분`;
+    } else {
+      const tomorrow = new Date(currentDate);
+      tomorrow.setDate(currentDate.getDate() + 1);
+
+      const isTomorrow = tomorrow.toDateString() === targetDate.toDateString();
+
+      if (isTomorrow) {
+        const hours = targetDate.getHours();
+        const minutes = targetDate.getMinutes();
+        return `내일, ${hours}시 ${minutes}분`;
+      } else {
+        const month = String(targetDate.getMonth() + 1).padStart(2, '0');
+        const day = String(targetDate.getDate()).padStart(2, '0');
+        const hours = targetDate.getHours();
+        const minutes = targetDate.getMinutes();
+        return `${month}/${day} ${hours}시 ${minutes}분`;
+      }
+    }
+  }
 
   // ======= postId 전달
   const moreInfoAction = event => {
@@ -173,7 +211,7 @@ export default function Post({ data, accountName, modalOpen, getPostId }) {
               <li className={styles.date}>
                 일시
                 <span className={styles['date-value']}>
-                  {planContents['date']}
+                  {formattedPlanDate}
                 </span>
               </li>
               <li className={styles.personnel}>
@@ -227,7 +265,7 @@ export default function Post({ data, accountName, modalOpen, getPostId }) {
               </span>
             </div>
           </div>
-          <span className={styles['create-date']}>{formattedDate}</span>
+          <span className={styles['create-date']}>{formattedCreateDate}</span>
         </div>
         <button
           className={styles['btn-post-more']}


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 폴더, 파일 등 업로드
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 게시물 업로드 날짜 기준으로 일시가 계산 되도록 수정(원인: 업로드 할 때, 날짜를 계산하여 텍스트로 넘기던 것이 문제였음)
- 수정 전
![스크린샷 2023-07-30 오전 4 29 11](https://github.com/FRONTENDSCHOOL5/final-25-would-you/assets/96880673/86d23bef-7d06-4f74-9d7a-254fb5995fa6)

- 수정 후
![스크린샷 2023-07-30 오전 4 27 52](https://github.com/FRONTENDSCHOOL5/final-25-would-you/assets/96880673/19c4b735-a40c-404d-9b08-1216bba8904f)

  

## 이슈 번호
closed: #214