### PR TITLE
[feat] follow페이지 리팩토링 #206

### DIFF
--- a/src/pages/Follow/Follow.module.css
+++ b/src/pages/Follow/Follow.module.css
@@ -19,20 +19,28 @@
 .followers-photo {
   width: 48.81px;
   height: 48.81px;
-  background: url(../../assets/images/profile-img42.png) no-repeat center center;
-  background-size: cover;
   grid-column: 1 / 2;
   grid-row: 1 / 3;
   gap: 0;
+  position: relative;
+  cursor: pointer;
 }
-
 .followers-photo img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   border-radius: 50px;
 }
-
+.followers-photo-bg {
+  width: 100%;
+  height: 100%;
+  background: url(../../assets/images/profile-img42.png) no-repeat center center;
+  background-size: cover;
+  border-radius: 50px;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
 /* 팔로워의 이름,소개,버튼을 묶은 그룹*/
 .followers-inner {
   margin-left: -45px;
@@ -49,6 +57,7 @@
   font-weight: 700;
   grid-column: 2 / 3;
   grid-row: 1 / 2;
+  cursor: pointer;
 }
 /* 팔로워 소개글 */
 .followers-info {

--- a/src/pages/Follow/Followers/Followers.jsx
+++ b/src/pages/Follow/Followers/Followers.jsx
@@ -37,6 +37,8 @@ export default function Followings() {
     }
   }, [followers.length, accountname, user.token]);
 
+  console.log('Followers 데이터 확인:', followers);
+
   const updateButtonState = index => {
     setButtonStates(prevStates => {
       const updatedStates = [...prevStates];
@@ -54,6 +56,7 @@ export default function Followings() {
   return (
     <Layout>
       <h2 className="a11y-hidden">팔로잉 목록</h2>
+
       <section className={styles['followers-list']}>
         {followers.length > 0 ? (
           followers.map((follower, index) => (
@@ -80,14 +83,17 @@ export default function Followings() {
               >
                 {follower.intro}
               </p>
-              <button
-                type="button"
-                id={`btn-${index}`}
-                className={`${styles['followers-btn']} ${buttonStates[index]?.className}`}
-                onClick={() => updateButtonState(index)}
-              >
-                {buttonStates[index]?.text}
-              </button>
+
+              {follower.accountname !== user.accountname && (
+                <button
+                  type="button"
+                  id={`btn-${index}`}
+                  className={`${styles['followers-btn']} ${buttonStates[index]?.className}`}
+                  onClick={() => updateButtonState(index)}
+                >
+                  {buttonStates[index]?.text}
+                </button>
+              )}
             </article>
           ))
         ) : (

--- a/src/pages/Follow/Followers/Followers.jsx
+++ b/src/pages/Follow/Followers/Followers.jsx
@@ -22,7 +22,7 @@ export default function Followings() {
         setFollowers(response);
         console.log('response 데이터 확인:', response);
 
-        // 각 팔로워의 초기 버튼 상태 설정
+        // 각 팔로워의 초기 버튼 상태 설정, api 하게 되면 필요없는 코드가 될수 있음
         const initialButtonStates = new Array(response.length).fill({
           text: '삭제',
           className: styles['followers-btn-unfollow'],
@@ -40,7 +40,7 @@ export default function Followings() {
 
   console.log('Followers 데이터 확인:', followers);
 
-  //팔로우 삭제 버튼
+  //팔로우 삭제 버튼 들어갈 텍스트 값을 구분해주면
   const updateButtonState = index => {
     setButtonStates(prevStates => {
       const updatedStates = [...prevStates];

--- a/src/pages/Follow/Followers/Followers.jsx
+++ b/src/pages/Follow/Followers/Followers.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
+// import { useHistory } from 'react-router-dom';
 import styles from '../Follow.module.css';
 import Layout from '../../../components/layout/Layout';
 import { AuthContext } from '../../../context/AuthContext';
@@ -10,6 +11,7 @@ export default function Followings() {
   const [buttonStates, setButtonStates] = useState([]);
   const { user } = useContext(AuthContext);
   const { accountname } = useParams();
+  // const history = useHistory();
 
   useEffect(() => {
     const fetchFollowers = async () => {
@@ -23,8 +25,8 @@ export default function Followings() {
 
         // 각 팔로워의 초기 버튼 상태 설정
         const initialButtonStates = new Array(response.length).fill({
-          text: '팔로우',
-          className: styles['followers-btn-follow'],
+          text: '삭제',
+          className: styles['followers-btn-unfollow'],
         });
         setButtonStates(initialButtonStates);
       } catch (error) {
@@ -43,7 +45,7 @@ export default function Followings() {
     setButtonStates(prevStates => {
       const updatedStates = [...prevStates];
       updatedStates[index] = {
-        text: prevStates[index].text === '팔로우' ? '취소' : '팔로우',
+        text: prevStates[index].text === '팔로우' ? '삭제' : '팔로우',
         className:
           prevStates[index].className === styles['followers-btn-follow']
             ? styles['followers-btn-unfollow']
@@ -53,10 +55,14 @@ export default function Followings() {
     });
   };
 
+  // 프로필 페이지로 이동하는 함수
+  // const navigateToProfile = accountname => {
+  //   history.push(`/profile/${accountname}`);
+  // };
+
   return (
     <Layout>
       <h2 className="a11y-hidden">팔로잉 목록</h2>
-
       <section className={styles['followers-list']}>
         {followers.length > 0 ? (
           followers.map((follower, index) => (
@@ -67,14 +73,20 @@ export default function Followings() {
               className={styles.followers}
             >
               <div className={styles['followers-photo']}>
-                <img
-                  src={follower.image}
-                  alt="프로필 사진"
-                  className={styles['followers-photo']}
-                />
+                {!follower.image && (
+                  <div className={styles['followers-photo-bg']} />
+                )}
+                {follower.image && (
+                  <img
+                    src={follower.image}
+                    alt="프로필 사진"
+                    className={styles['followers-photo-img']}
+                  />
+                )}
               </div>
               <p
                 className={`${styles['followers-inner']} ${styles['followers-name']}`}
+                // onClick={() => navigateToProfile(follower.accountname)}
               >
                 {follower.username}
               </p>
@@ -83,7 +95,6 @@ export default function Followings() {
               >
                 {follower.intro}
               </p>
-
               {follower.accountname !== user.accountname && (
                 <button
                   type="button"

--- a/src/pages/Follow/Followers/Followers.jsx
+++ b/src/pages/Follow/Followers/Followers.jsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect, useContext } from 'react';
-// import { useHistory } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import styles from '../Follow.module.css';
 import Layout from '../../../components/layout/Layout';
 import { AuthContext } from '../../../context/AuthContext';
-import { useParams } from 'react-router-dom';
 import profileAPI from '../../../api/profileAPI2';
 
 export default function Followings() {
@@ -11,7 +10,7 @@ export default function Followings() {
   const [buttonStates, setButtonStates] = useState([]);
   const { user } = useContext(AuthContext);
   const { accountname } = useParams();
-  // const history = useHistory();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchFollowers = async () => {
@@ -41,6 +40,7 @@ export default function Followings() {
 
   console.log('Followers 데이터 확인:', followers);
 
+  //팔로우 버튼
   const updateButtonState = index => {
     setButtonStates(prevStates => {
       const updatedStates = [...prevStates];
@@ -54,11 +54,6 @@ export default function Followings() {
       return updatedStates;
     });
   };
-
-  // 프로필 페이지로 이동하는 함수
-  // const navigateToProfile = accountname => {
-  //   history.push(`/profile/${accountname}`);
-  // };
 
   return (
     <Layout>
@@ -81,12 +76,13 @@ export default function Followings() {
                     src={follower.image}
                     alt="프로필 사진"
                     className={styles['followers-photo-img']}
+                    onClick={() => navigate(`/profile/${follower.accountname}`)}
                   />
                 )}
               </div>
               <p
                 className={`${styles['followers-inner']} ${styles['followers-name']}`}
-                // onClick={() => navigateToProfile(follower.accountname)}
+                onClick={() => navigate(`/profile/${follower.accountname}`)}
               >
                 {follower.username}
               </p>

--- a/src/pages/Follow/Followings/Followings.jsx
+++ b/src/pages/Follow/Followings/Followings.jsx
@@ -23,8 +23,8 @@ export default function Followers() {
 
         // 각 팔로워의 초기 버튼 상태 설정
         const initialButtonStates = new Array(response.length).fill({
-          text: '팔로우',
-          className: styles['followers-btn-follow'],
+          text: '취소',
+          className: styles['followers-btn-unfollow'],
         });
         setButtonStates(initialButtonStates);
       } catch (error) {
@@ -41,11 +41,11 @@ export default function Followers() {
     setButtonStates(prevStates => {
       const updatedStates = [...prevStates];
       updatedStates[index] = {
-        text: prevStates[index].text === '팔로우' ? '취소' : '팔로우',
+        text: prevStates[index].text === '취소' ? '팔로우' : '취소',
         className:
-          prevStates[index].className === styles['followers-btn-follow']
-            ? styles['followers-btn-unfollow']
-            : styles['followers-btn-follow'],
+          prevStates[index].className === styles['followers-btn-unfollow']
+            ? styles['followers-btn-follow']
+            : styles['followers-btn-unfollow'],
       };
       return updatedStates;
     });
@@ -64,11 +64,16 @@ export default function Followers() {
               className={styles.followers}
             >
               <div className={styles['followers-photo']}>
-                <img
-                  src={follower.image}
-                  alt="프로필 사진"
-                  className={styles['followers-photo']}
-                />
+                {!follower.image && (
+                  <div className={styles['followers-photo-bg']} />
+                )}
+                {follower.image && (
+                  <img
+                    src={follower.image}
+                    alt="프로필 사진"
+                    className={styles['followers-photo-img']}
+                  />
+                )}
               </div>
               <p
                 className={`${styles['followers-inner']} ${styles['followers-name']}`}

--- a/src/pages/Follow/Followings/Followings.jsx
+++ b/src/pages/Follow/Followings/Followings.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useContext } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import styles from '../Follow.module.css';
 import Layout from '../../../components/layout/Layout';
 import { AuthContext } from '../../../context/AuthContext';
-import { useParams } from 'react-router-dom';
 import profileAPI from '../../../api/profileAPI2';
 
 export default function Followers() {
@@ -10,6 +10,7 @@ export default function Followers() {
   const [buttonStates, setButtonStates] = useState([]);
   const { user } = useContext(AuthContext);
   const { accountname } = useParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchFollowers = async () => {
@@ -37,6 +38,7 @@ export default function Followers() {
     }
   }, [followers.length, accountname, user.token]);
 
+  //팔로우 버튼
   const updateButtonState = index => {
     setButtonStates(prevStates => {
       const updatedStates = [...prevStates];
@@ -72,11 +74,13 @@ export default function Followers() {
                     src={follower.image}
                     alt="프로필 사진"
                     className={styles['followers-photo-img']}
-                  />
+                    onClick={() => navigate(`/profile/${follower.accountname}`)}
+                  ></img>
                 )}
               </div>
               <p
                 className={`${styles['followers-inner']} ${styles['followers-name']}`}
+                onClick={() => navigate(`/profile/${follower.accountname}`)} // followers-name을 클릭할 때 이동
               >
                 {follower.username}
               </p>


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 폴더, 파일 등 업로드
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 팔로워 팔로잉 페이지 내계정 버튼은 안보이게 구현 기능 추가
- 팔로워 팔로잉 리스트 프로필사진 백그라운드 겹침 현상 수정
- 팔로워 팔로잉 리스트 프로필사진과 계정이름 커서 변경
- 팔로잉 리스트 버튼 수정 및 api 연동(언팔기능 구현)
- 팔로워 팔로잉 페이지에서 유저 클릭시 해당 유저 프로필로 이동 기능 구현
## 이슈 번호
closed: #206 