### PR TITLE
[feat] 게시글 이미지가 2개 이상일 때 여러장의 이미지가 보여질 수 있도록 코드 추가 #228

### DIFF
--- a/src/components/common/Post/Post.jsx
+++ b/src/components/common/Post/Post.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from './Post.module.css';
-import basicProfileImg from '../../../assets/images/basic-profile-img.png';
 
 export default function Post({ data, accountName, modalOpen, getPostId }) {
   console.log('props로 전달받은 data: ', data);
@@ -162,6 +161,27 @@ export default function Post({ data, accountName, modalOpen, getPostId }) {
     }
   }
 
+  // ===== 이미지 리스트 생성
+  const [imageList, setImageList] = useState([]);
+  const [isImage, setIsImage] = useState(false);
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+
+  // 버튼 클릭 이벤트
+  const handleImageControlClick = (event, index) => {
+    setCurrentImageIndex(index);
+    const imageContainer = event.target.parentElement.closest('div').firstChild;
+    const translateXValue = -309 * index;
+    imageContainer.style.transform = `translateX(${translateXValue}px)`;
+    imageContainer.style.transition = 'transform 0.5s'; // 트랜지션 효과 설정
+  };
+
+  useEffect(() => {
+    if (data['image'] !== '') {
+      setIsImage(true);
+      setImageList(data['image'].split(','));
+    }
+  }, [data['image']]);
+
   // ======= postId 전달
   const moreInfoAction = event => {
     modalOpen(event);
@@ -224,23 +244,38 @@ export default function Post({ data, accountName, modalOpen, getPostId }) {
           )}
 
           <div className={styles['post-img-container']}>
-            <ul className={styles['post-img-list']}>
-              {data['image'] ? (
-                <li className={`${styles['post-img']} ${styles['on']}`}>
-                  <img src={data['image']} alt="음식 사진" />
-                </li>
-              ) : (
-                <></>
-              )}
-            </ul>
-            <ul className={styles['post-img-control']}>
-              <li>
-                <button className={styles['on']} type="button"></button>
-              </li>
-              <li>
-                <button className="" type="button"></button>
-              </li>
-            </ul>
+            {isImage ? (
+              <ul
+                className={styles['post-img-list']}
+                style={{
+                  transform: `translateX(${-309 * currentImageIndex}px)`,
+                }}
+              >
+                {imageList.map((imageUrl, index) => (
+                  <li key={index} className={styles['on']}>
+                    <img src={imageUrl} alt={`음식 사진 ${index + 1}`} />
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <></>
+            )}
+
+            {imageList.length > 1 && (
+              <ul className={styles['post-img-control']}>
+                {imageList.map((_, index) => (
+                  <li key={index}>
+                    <button
+                      className={
+                        index === currentImageIndex ? styles['on'] : ''
+                      }
+                      type="button"
+                      onClick={event => handleImageControlClick(event, index)}
+                    ></button>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
           <p className={styles['post-text']}>
             {planContents

--- a/src/components/common/Post/Post.module.css
+++ b/src/components/common/Post/Post.module.css
@@ -3,7 +3,7 @@
 /* 포스트 */
 .btn-group {
   text-align: right;
-  border-bottom: 0.5px solid #DBDBDB;
+  border-bottom: 0.5px solid #dbdbdb;
   padding: 9px 21px;
 }
 .btn-group button {
@@ -73,9 +73,9 @@
   text-align: left;
   color: #585858;
   margin: 20px 0;
-  grid-template-areas: 
-  "a b"
-  "c d";
+  grid-template-areas:
+    'a b'
+    'c d';
 }
 .plan-list span {
   width: 108px;
@@ -108,7 +108,7 @@
   height: 14px;
   border-radius: 10px;
   background: var(--sub-color-2);
-  vertical-align:text-bottom;
+  vertical-align: text-bottom;
   margin: 0 6px;
 }
 
@@ -148,12 +148,10 @@
   display: block;
   width: 309px;
   height: 228px;
-  border: 0.5px solid #DBDBDB;
+  border: 0.5px solid #dbdbdb;
   border-radius: 10px;
   margin-right: 2px;
-}
-.post-img-list li.on{
-  transform: all 0.5s;
+  transition: transform 0.5s; /* transform 속성에 대해 0.5초의 트랜지션 효과 적용 */
 }
 .post-img-list li img {
   width: 100%;
@@ -207,12 +205,12 @@
   display: flex;
 }
 .btn-like {
-  background: #FFFFFF;
+  background: #ffffff;
   border: none;
   color: inherit;
 }
 .btn-like::before,
-.comment::before{
+.comment::before {
   content: '';
   width: 20px;
   height: 20px;

--- a/src/components/common/Profile/ProfilePost.jsx
+++ b/src/components/common/Profile/ProfilePost.jsx
@@ -130,23 +130,25 @@ export default function ProfilePost({
     feed: !feedList.length ? (
       <FeedNone />
     ) : (
-      <section className={styles.feed}>
-        <ul className={styles['post-list']}>
-          {feedList.map(item => {
-            return (
-              <li key={item.id}>
-                <Post
-                  data={item}
-                  account={accountName}
-                  modalOpen={modalOpen}
-                  getPostId={getPostId}
-                />
-              </li>
-            );
-          })}
-        </ul>
-        <div ref={ref}></div>
-      </section>
+      !isLoading && (
+        <section className={styles.feed}>
+          <ul className={styles['post-list']}>
+            {feedList.map(item => {
+              return (
+                <li key={item.id}>
+                  <Post
+                    data={item}
+                    account={accountName}
+                    modalOpen={modalOpen}
+                    getPostId={getPostId}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+          <div ref={ref}></div>
+        </section>
+      )
     ),
     post: (
       <section className={styles.post}>


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [x] 기능 추가

## 변경 사항
- 업로드된 이미지가 여러장일 때도 이미지가 나타나도록 코드 추가
  - 이미지 하단 버튼을 클릭하면 해당 순서의 이미지로 넘어갑니다.
  
     ![화면_기록_2023-07-30_오후_5_57_52_AdobeExpress](https://github.com/FRONTENDSCHOOL5/final-25-would-you/assets/96880673/701bcc84-9a60-483e-9850-aa99dbae5ecf)


## 이슈 번호
closed: #228 