### PR TITLE
[fix] 공구 중인 상품이 없을 때는, 영역 안보이게 처리 #234

### DIFF
--- a/src/components/common/Profile/ProfileProduct.jsx
+++ b/src/components/common/Profile/ProfileProduct.jsx
@@ -40,7 +40,7 @@ export default function ProductList({
 
   return (
     <>
-      {product.length !== 0 || !isLoading ? (
+      {product.length !== 0 && !isLoading ? (
         <section className={styles.product}>
           <h2 className={styles['product-title']}>공구 중인 상품</h2>
           <ul className={styles['product-list']}>


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [x] 버그 수정

## 변경 사항
- 공구 중인 상품이 없을 때는 영역이 안보이도록 수정
- 원인: 87dffa8a6f59eecc07fe89fd710a3444309939c7 여기서 잘못고침..


## 이슈 번호
closed: #234 