### PR TITLE
[fix] 피드 스크롤이 하단으로 가면 다시 최상단으로 올라가는 이슈 수정 #236

### DIFF
--- a/src/components/common/Profile/ProfilePost.jsx
+++ b/src/components/common/Profile/ProfilePost.jsx
@@ -130,25 +130,23 @@ export default function ProfilePost({
     feed: !feedList.length ? (
       <FeedNone />
     ) : (
-      !isLoading && (
-        <section className={styles.feed}>
-          <ul className={styles['post-list']}>
-            {feedList.map(item => {
-              return (
-                <li key={item.id}>
-                  <Post
-                    data={item}
-                    account={accountName}
-                    modalOpen={modalOpen}
-                    getPostId={getPostId}
-                  />
-                </li>
-              );
-            })}
-          </ul>
-          <div ref={ref}></div>
-        </section>
-      )
+      <section className={styles.feed}>
+        <ul className={styles['post-list']}>
+          {feedList.map(item => {
+            return (
+              <li key={item.id}>
+                <Post
+                  data={item}
+                  account={accountName}
+                  modalOpen={modalOpen}
+                  getPostId={getPostId}
+                />
+              </li>
+            );
+          })}
+        </ul>
+        <div ref={ref}></div>
+      </section>
     ),
     post: (
       <section className={styles.post}>


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [x] 버그 수정

## 변경 사항
- 피드에서 스크롤이 하단으로 가면 다시 최상단으로 올라가는 이슈 수정하여, 지금은 스크롤 움직임 없이 게시글이 잘 로딩됨.
- 원인: 3fce04743da7598e32e7f706bae0924027b2f950 여기서 영향받음...
- 수정 전: 스크롤이 하단으로 가면 다시 최상단으로 올라감
![화면_기록_2023-07-30_오후_6_44_05_AdobeExpress](https://github.com/FRONTENDSCHOOL5/final-25-would-you/assets/96880673/1168f1a1-33f1-45c3-9f6b-539c685ffb9b)

- 수정 후: 스크롤이 하단으로 가도 최상단으로 가지 않도록 수정
![화면_기록_2023-07-30_오후_6_51_50_AdobeExpress](https://github.com/FRONTENDSCHOOL5/final-25-would-you/assets/96880673/d1c424ca-3c75-4242-9268-100cb61c2a92)



## 이슈 번호
closed: #236