### PR TITLE
[fix] 게시글 마지막 이미지 볼 때, 왼쪽에 두번째 이미지가 잘려보이는 이슈 수정

### DIFF
--- a/src/components/common/Post/Post.module.css
+++ b/src/components/common/Post/Post.module.css
@@ -150,7 +150,6 @@
   height: 228px;
   border: 0.5px solid #dbdbdb;
   border-radius: 10px;
-  margin-right: 2px;
   transition: transform 0.5s; /* transform 속성에 대해 0.5초의 트랜지션 효과 적용 */
 }
 .post-img-list li img {


### PR DESCRIPTION
## 코드 생성 및 수정 이유
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 폴더, 파일 등 업로드
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- li 태그에 margin 삭제하여 이슈 수정

## 이슈 번호
closed: #256